### PR TITLE
[frontend] ci: remove missing reference

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -7,10 +7,6 @@ on:
       - develop
     paths:
       - frontend/**
-  push:
-    branches:
-      - develop
-    paths:
       - .github/workflows/frontend-deploy.yml
 defaults:
   run:


### PR DESCRIPTION
対象のアクションは PR が閉じられた後に回るアクションです．PR によってベースブランチ( PR の矢印が向いている先のブランチ)は消されているため github.head_ref にチェックアウトするのは不適切でした．そもそも github.head_ref は `develop <- featXX` の向きにマージしたとすると featXX 側なので「develop にマージされたら**そのマージされたときの develop のコミットにチェックアウトして**アクションを回す」という今回の目的からしてもやはり変でした．すいません．