### PR TITLE
[backend] use mariadb instead of mysql

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -28,13 +28,14 @@ func main() {
 		log.Fatal(err)
 	}
 	mysqlConfig := &mysql.Config{
-		DBName:    config.DBName,
-		User:      config.DBUser,
-		Passwd:    config.DBPass,
-		Addr:      config.DBAddr,
-		Net:       "tcp",
-		ParseTime: true,
-		Loc:       jst,
+		DBName:               config.DBName,
+		User:                 config.DBUser,
+		Passwd:               config.DBPass,
+		Addr:                 config.DBAddr,
+		Net:                  "tcp",
+		ParseTime:            true,
+		Loc:                  jst,
+		AllowNativePasswords: true,
 	}
 	entClient, err := ent.Open("mysql", mysqlConfig.FormatDSN())
 	if err != nil {

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,7 @@ services:
     env_file:
       - .env
   db:
-    image: mysql:8.0
+    image: mariadb:11.1
     restart: always
     ports:
       - 3306:3306


### PR DESCRIPTION
## 概要

mysql でなく mariadb を使うようにした

## 背景

mariadb > mysql