### PR TITLE
[frontend] 手元で GitHub Actions 回すときのエラー回避

### DIFF
--- a/.github/workflows/frontend-deploy-preview.yml
+++ b/.github/workflows/frontend-deploy-preview.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.STORE_PATH }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.STORE_PATH }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml')
             }}
           restore-keys: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Setup pnpm cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.STORE_PATH }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ${{ github.workspace }}/.next/cache
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('frontend/pnpm-lock.yaml')
             }}
           restore-keys: |


### PR DESCRIPTION
## この PR で解決されること
- ローカルで [nektos/act](https://github.com/nektos/act) を使用して GitHub Actions を試しに回してみると，エラーが出る．
- このエラーを直して正しく pnpm のセットアップ及び pnpm i がローカルの act でもできるように修正する
  - ワークフローファイルの該当する step の順序を直前の step と入れ替えたら直った．

## エラーの内容

(追記)コマンドや act のバージョンなど

<details>
<summary>検証したコマンドと実行結果</summary>

```bash
$ act -W .github/workflows/frontend.yml -e /tmp/pull-request.json

INFO[0000] deleted cache: &{ID:1 Key:golangci-lint.cache-2799-9616be2c225cb97408852538b2de94628cb3cc08 Version:7fe0792f6e387751b022d978488ef617e1f1afcaac6ac078dcdeb7d29cb1c439 KeyVersionHash:64c331405100a0833e32cd2dec3ad107e186a4ba1882d0058df9cb95194b2e82 Size:76412429 Complete:true UsedAt:1693232899 CreatedAt:1693148311}  module=artifactcache
[frontend/Lint & Build & Format] 🚀  Start image=catthehacker/ubuntu:act-latest
[frontend/Lint & Build & Format]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[frontend/Lint & Build & Format] using DockerAuthConfig authentication for docker pull
[frontend/Lint & Build & Format]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[frontend/Lint & Build & Format]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[frontend/Lint & Build & Format]   ☁  git clone 'https://github.com/actions/setup-node' # ref=v3
[frontend/Lint & Build & Format]   ☁  git clone 'https://github.com/pnpm/action-setup' # ref=v2
[frontend/Lint & Build & Format]   ☁  git clone 'https://github.com/actions/cache' # ref=v3
[frontend/Lint & Build & Format]   ☁  git clone 'https://github.com/stefanzweifel/git-auto-commit-action' # ref=v4
[frontend/Lint & Build & Format] ⭐ Run Main actions/checkout@v3
[frontend/Lint & Build & Format]   🐳  docker cp src=/home/youtaku/prog/github.com/szpp-dev-team/szpp-judge/. dst=/home/youtaku/prog/github.com/szpp-dev-team/szpp-judge
[frontend/Lint & Build & Format]   ✅  Success - Main actions/checkout@v3
[frontend/Lint & Build & Format] ⭐ Run Main actions/setup-node@v3
[frontend/Lint & Build & Format]   🐳  docker cp src=/home/youtaku/.cache/act/actions-setup-node@v3/ dst=/var/run/act/actions/actions-setup-node@v3/
[frontend/Lint & Build & Format]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-node@v3/dist/setup/index.js] user= workdir=
| Node version file is not JSON file
| Resolved frontend/.node-version as 20.5.1
[frontend/Lint & Build & Format]   💬  ::debug::isExplicit: 20.5.1
[frontend/Lint & Build & Format]   💬  ::debug::explicit? true
[frontend/Lint & Build & Format]   💬  ::debug::checking cache: /opt/hostedtoolcache/node/20.5.1/x64
[frontend/Lint & Build & Format]   💬  ::debug::not found
| Attempting to download 20.5.1...
[frontend/Lint & Build & Format]   💬  ::debug::No manifest cached
[frontend/Lint & Build & Format]   💬  ::debug::Getting manifest from actions/node-versions@main
[frontend/Lint & Build & Format]   💬  ::debug::check 20.5.1 satisfies 20.5.1
[frontend/Lint & Build & Format]   💬  ::debug::x64===x64 && darwin===linux
[frontend/Lint & Build & Format]   💬  ::debug::x64===x64 && linux===linux
[frontend/Lint & Build & Format]   💬  ::debug::matched 20.5.1
| Acquiring 20.5.1 - x64 from https://github.com/actions/node-versions/releases/download/20.5.1-5819736097/node-20.5.1-linux-x64.tar.gz
[frontend/Lint & Build & Format]   💬  ::debug::Downloading https://github.com/actions/node-versions/releases/download/20.5.1-5819736097/node-20.5.1-linux-x64.tar.gz
[frontend/Lint & Build & Format]   💬  ::debug::Destination /tmp/ae6feebe-b636-4908-82c7-d5d0631ead22
[frontend/Lint & Build & Format]   💬  ::debug::download complete
| Extracting ...
[frontend/Lint & Build & Format]   💬  ::debug::Checking tar --version
[frontend/Lint & Build & Format]   💬  ::debug::tar (GNU tar) 1.34%0ACopyright (C) 2021 Free Software Foundation, Inc.%0ALicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.%0AThis is free software: you are free to change and redistribute it.%0AThere is NO WARRANTY, to the extent permitted by law.%0A%0AWritten by John Gilmore and Jay Fenlason.
| [command]/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword -C /tmp/4afee3b3-5351-451d-80d0-3cd997adf845 -f /tmp/ae6feebe-b636-4908-82c7-d5d0631ead22
| Adding to the cache ...
[frontend/Lint & Build & Format]   💬  ::debug::Caching tool node 20.5.1 x64
[frontend/Lint & Build & Format]   💬  ::debug::source dir: /tmp/4afee3b3-5351-451d-80d0-3cd997adf845
[frontend/Lint & Build & Format]   💬  ::debug::destination /opt/hostedtoolcache/node/20.5.1/x64
[frontend/Lint & Build & Format]   💬  ::debug::finished caching tool
[frontend/Lint & Build & Format]   ❓  ::group::Environment details
| node: v20.5.1
| npm: 9.8.0
| yarn:
[frontend/Lint & Build & Format]   ❓  ::endgroup::
[frontend/Lint & Build & Format]   ❓ add-matcher /run/act/actions/actions-setup-node@v3/.github/tsc.json
[frontend/Lint & Build & Format]   ❓ add-matcher /run/act/actions/actions-setup-node@v3/.github/eslint-stylish.json
[frontend/Lint & Build & Format]   ❓ add-matcher /run/act/actions/actions-setup-node@v3/.github/eslint-compact.json
[frontend/Lint & Build & Format]   ✅  Success - Main actions/setup-node@v3
[frontend/Lint & Build & Format]   ⚙  ::set-output:: node-version=v20.5.1
[frontend/Lint & Build & Format]   ⚙  ::add-path:: /opt/hostedtoolcache/node/20.5.1/x64/bin
[frontend/Lint & Build & Format] ⭐ Run Main Install pnpm
[frontend/Lint & Build & Format]   🐳  docker cp src=/home/youtaku/.cache/act/pnpm-action-setup@v2/ dst=/var/run/act/actions/pnpm-action-setup@v2/
[frontend/Lint & Build & Format]   🐳  docker exec cmd=[node /var/run/act/actions/pnpm-action-setup@v2/dist/index.js] user= workdir=
[frontend/Lint & Build & Format]   ❓  ::group::Running self-installer...
|  WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
|  WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
^C[frontend/Lint & Build & Format]   ❌  Failure - Main Install pnpm
[frontend/Lint & Build & Format] Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.43/containers/f5ded89d00b7df14c043d3312a1179422935170033b0d5472d485f3e2d04a04c/archive?path=%2Fvar%2Frun%2Fact%2Fworkflow%2Fpathcmd.txt": context canceled
[frontend/Lint & Build & Format] ⭐ Run Post Install pnpm
[frontend/Lint & Build & Format]   🐳  docker exec cmd=[node /var/run/act/actions/pnpm-action-setup@v2/dist/index.js] user= workdir=
[frontend/Lint & Build & Format]   ❓  ::group::Running self-installer...
|  WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
|  WARN  GET https://registry.npmjs.org/pnpm error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
|  ERR_PNPM_META_FETCH_FAIL  GET https://registry.npmjs.org/pnpm: Value of "this" must be of type URLSearchParams
[frontend/Lint & Build & Format]   ❓  ::endgroup::
[frontend/Lint & Build & Format]   ❗  ::error::Something went wrong, self-installer exits with code 1
| Installation Completed!
[frontend/Lint & Build & Format]   ❌  Failure - Post Install pnpm
[frontend/Lint & Build & Format]   ⚙  ::set-output:: dest=/root/setup-pnpm
[frontend/Lint & Build & Format]   ⚙  ::set-output:: bin_dest=/root/setup-pnpm/node_modules/.bin
[frontend/Lint & Build & Format]   ⚙  ::add-path:: /root/setup-pnpm/node_modules/.bin
[frontend/Lint & Build & Format]   ⚙  ::add-path:: /root/setup-pnpm/node_modules/.bin

# /tmp/pull-request.json の内容は今回重要ではありませんが次の通りです
# {"pull_request":{"head":{"ref":"fix/pnpm-act-failue"},"base":{"ref": "develop"}}}
```

</details>

- 検証したコミット 32007fb26775104bfaeddf036c91c16f0fdff2a2
- 該当箇所
  https://github.com/szpp-dev-team/szpp-judge/blob/32007fb26775104bfaeddf036c91c16f0fdff2a2/.github/workflows/frontend.yml#L26-L34
- act のバージョン `act version 0.2.49`
- OS Arch Linux(x86_64 Linux 6.4.12-arch1-1)

act だとエラーになりますが GitHub 上で実際に Actions を回すとエラーは起きないのでおま環ではあるのですが actions/setup-node と pnpm/action-setup を逆にしたら何故か直ったのでそれをコミットします．GitHub 上での実行には変化ないはずです．たぶん．