### PR TITLE
[backend] ci を修正

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -5,6 +5,7 @@ on:
       - develop
     paths:
       - backend/**
+      - proto-gen/go/**
       - .github/workflows/backend.yml
 defaults:
   run:


### PR DESCRIPTION
## 概要

多分 `proto-gen/go/**` を trigger 対象に含めていなかったのが原因で動いていなかったのでそれを修正