### PR TITLE
ci: proto から生成されるコードの変更のみならデプロイのトリガーから外す (push のとき)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,6 +12,7 @@ on:
       - develop
     paths:
       - frontend/**
+      - '!frontend/src/gen/**'
       - .github/workflows/frontend.yml
 defaults:
   run:


### PR DESCRIPTION
`.github/workflows/frontend.yml` について，本来 #36 でやるべき作業の漏れてた分です．pull_request のトリガーはカバーしてたのですが push のときを忘れてました．