### PR TITLE
ci: ワークフローを手動実行できるようにする(フロントエンド向け)

### DIFF
--- a/.github/workflows/frontend-deploy-preview.yml
+++ b/.github/workflows/frontend-deploy-preview.yml
@@ -7,6 +7,7 @@ on:
       - frontend/**
       - '!frontend/src/gen/**'
       - .github/workflows/frontend-deploy-preview.yml
+  workflow_dispatch:
 defaults:
   run:
     working-directory: ./frontend

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -9,6 +9,7 @@ on:
       - frontend/**
       - '!frontend/src/gen/**'
       - .github/workflows/frontend-deploy.yml
+  workflow_dispatch:
 defaults:
   run:
     working-directory: ./frontend

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,6 +14,7 @@ on:
       - frontend/**
       - '!frontend/src/gen/**'
       - .github/workflows/frontend.yml
+  workflow_dispatch:
 defaults:
   run:
     working-directory: ./frontend


### PR DESCRIPTION
ワークフローを GitHub 上や github cli などから手動実行できるようにする設定を追加しました．

[ワークフローの手動実行](https://docs.github.com/ja/actions/using-workflows/manually-running-a-workflow) によれば「ワークフローファイルが既定のブランチにある」ことが実行するための条件らしく，一旦既定のブランチ(develop) にマージしてしまいます．