### PR TITLE
[backend] Preflight Request が失敗するのを修正

### DIFF
--- a/backend/api/connect_server/connect_server.go
+++ b/backend/api/connect_server/connect_server.go
@@ -1,6 +1,7 @@
 package connect_server
 
 import (
+	"log"
 	"net/http"
 
 	"connectrpc.com/connect"
@@ -47,6 +48,8 @@ func New(addr string, opts ...optionFunc) *http.Server {
 	mux.Handle(backendv1connect.NewAuthServiceHandler(authSrv, interceptors))
 
 	handler := h2c.NewHandler(mux, &http2.Server{})
+
+	log.Println(opt.FrontendURL)
 
 	// https://connectrpc.com/docs/go/deployment/#cors
 	corsHandler := cors.New(cors.Options{

--- a/backend/api/connect_server/connect_server.go
+++ b/backend/api/connect_server/connect_server.go
@@ -48,13 +48,35 @@ func New(addr string, opts ...optionFunc) *http.Server {
 
 	handler := h2c.NewHandler(mux, &http2.Server{})
 
-	corsConfig := cors.New(cors.Options{
+	// https://connectrpc.com/docs/go/deployment/#cors
+	corsHandler := cors.New(cors.Options{
+		AllowedMethods: []string{
+			http.MethodGet,
+			http.MethodPost,
+		},
 		AllowedOrigins: []string{"http://localhost:5000", "http://localhost:3000", opt.FrontendURL},
-		AllowedHeaders: []string{"Connect-Protocol-Version", "Content-Type"},
+		AllowedHeaders: []string{
+			"Accept-Encoding",
+			"Content-Encoding",
+			"Content-Type",
+			"Connect-Protocol-Version",
+			"Connect-Timeout-Ms",
+			"Connect-Accept-Encoding",  // Unused in web browsers, but added for future-proofing
+			"Connect-Content-Encoding", // Unused in web browsers, but added for future-proofing
+			"Grpc-Timeout",             // Used for gRPC-web
+			"X-Grpc-Web",               // Used for gRPC-web
+			"X-User-Agent",             // Used for gRPC-web
+		},
+		ExposedHeaders: []string{
+			"Content-Encoding",         // Unused in web browsers, but added for future-proofing
+			"Connect-Content-Encoding", // Unused in web browsers, but added for future-proofing
+			"Grpc-Status",              // Required for gRPC-web
+			"Grpc-Message",             // Required for gRPC-web
+		},
 	})
 
 	return &http.Server{
 		Addr:    addr,
-		Handler: corsConfig.Handler(handler),
+		Handler: corsHandler.Handler(handler),
 	}
 }

--- a/backend/api/connect_server/connect_server.go
+++ b/backend/api/connect_server/connect_server.go
@@ -50,6 +50,7 @@ func New(addr string, opts ...optionFunc) *http.Server {
 
 	corsConfig := cors.New(cors.Options{
 		AllowedOrigins: []string{"http://localhost:5000", "http://localhost:3000", opt.FrontendURL},
+		AllowedHeaders: []string{"Connect-Protocol-Version", "Content-Type"},
 	})
 
 	return &http.Server{


### PR DESCRIPTION
## 解決したい課題 :confused: 
- ブラウザからの Preflight Request が失敗し，それに伴ってその後にやりたい本命のリクエストがブラウザによってキャンセル :no_entry_sign: されてしまう

## どうなればよいか :laughing: 

OPTIONS リクエストに対して下記レスポンスがバックエンドから返されればよい
- HTTP/1.1 204 No Content
- Access-Control-Allow-Headers ヘッダがある
- Access-Control-Allow-Methods ヘッダが POST
- **Access-Control-Allow-Origin ヘッダがある & リクエストの Origin ヘッダの値と一致している**
- Vary ヘッダがある

## マージ前に確認したいこと
- [x] ローカルで動かしてみて Preflight Request を捌けることを確認する
- [ ] Cloud Run で確認する
  - 今のところのリビジョン szpp-judge-backend-00054-dph では OPTIONS リクエストに対して 405 Method Not Allowed が返ってきててこれは :no_good_man:  です．