### PR TITLE
[frontend] GetContestTaskResponse の新プロパティに合わせたモックなどの改修

### DIFF
--- a/frontend/src/mocks/handlers/contest.ts
+++ b/frontend/src/mocks/handlers/contest.ts
@@ -176,7 +176,7 @@ export const contestHandlers: RequestHandler[] = [
     }
     return res(
       ctx.delay(500),
-      encodeResp({ task }),
+      encodeResp({ task, samples: [] }), // FIXME: #109 を受けてとりあえずの対応なので後でちゃんとしたデータを入れる
     );
   }),
   connectMock(ContestService, "getMySubmissionStatuses", async (ctx, res, decodeReq, encodeResp) => {

--- a/frontend/src/usecases/contest.ts
+++ b/frontend/src/usecases/contest.ts
@@ -77,7 +77,8 @@ export const useGetContestTask = (input?: PlainMessage<GetContestTaskRequest>) =
     staleTime: 5 * Duration.MINUTE,
   });
   const task = data?.task;
-  return { task, error, isLoading };
+  const samples = data?.samples;
+  return { task, samples, error, isLoading };
 };
 
 export const useGetMySubmissionStatuses = (input?: PlainMessage<GetMySubmissionStatusesRequest>) => {


### PR DESCRIPTION
fix #109 一旦 CI を通すために最低限の対応

- getContestTask のモックから `{ task, samples: [] }` を返すように変更しただけ

ちゃんとした対応は #112 で行われるはず．そこまでのつなぎです．