### PR TITLE
[frontend] 提出ソースコード入力エリアに CodeMirror を使用

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@chakra-ui/next-js": "2.1.5",
     "@chakra-ui/react": "2.8.0",
     "@chakra-ui/styled-system": "^2.9.1",
+    "@codemirror/commands": "^6.3.0",
     "@codemirror/lang-cpp": "^6.0.2",
     "@codemirror/language": "^6.9.1",
     "@codemirror/state": "^6.2.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@chakra-ui/styled-system':
     specifier: ^2.9.1
     version: 2.9.1
+  '@codemirror/commands':
+    specifier: ^6.3.0
+    version: 6.3.0
   '@codemirror/lang-cpp':
     specifier: ^6.0.2
     version: 6.0.2
@@ -2663,6 +2666,15 @@ packages:
     dependencies:
       '@chakra-ui/system': 2.6.0(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(react@18.2.0)
       react: 18.2.0
+
+  /@codemirror/commands@6.3.0:
+    resolution: {integrity: sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==}
+    dependencies:
+      '@codemirror/language': 6.9.1
+      '@codemirror/state': 6.2.1
+      '@codemirror/view': 6.20.2
+      '@lezer/common': 1.1.0
+    dev: false
 
   /@codemirror/lang-cpp@6.0.2:
     resolution: {integrity: sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==}

--- a/frontend/src/components/model/judge/SubmissionEditor.tsx
+++ b/frontend/src/components/model/judge/SubmissionEditor.tsx
@@ -15,13 +15,13 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  Textarea,
   UnorderedList,
   useToast,
 } from "@chakra-ui/react";
 import path from "path";
 import { ChangeEventHandler, useRef, useState } from "react";
 import { IoPushSharp } from "react-icons/io5";
+import { Editor } from "../../ui/Editor";
 
 const activeLangIds = langIDs.filter((id) => langMetasBrief[id].active);
 
@@ -139,10 +139,10 @@ export const SubmissionEditor = ({
           accept={acceptedFileExtsCommnaJoined}
           onChange={handleFileAttach}
         />
-        <Textarea
-          rows={15}
-          value={sourceCode}
-          onChange={(e) => onSourceCodeChange(e.target.value)}
+        <Editor
+          doc={sourceCode}
+          onDocChange={onSourceCodeChange}
+          height="20rem"
         />
       </Box>
       {warnings.length > 0 && (

--- a/frontend/src/components/ui/Editor.tsx
+++ b/frontend/src/components/ui/Editor.tsx
@@ -1,3 +1,4 @@
+import { indentWithTab } from "@codemirror/commands";
 import { cpp } from "@codemirror/lang-cpp";
 import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { EditorState, EditorStateConfig } from "@codemirror/state";
@@ -8,6 +9,7 @@ import {
   highlightActiveLine,
   highlightActiveLineGutter,
   highlightSpecialChars,
+  keymap,
   lineNumbers,
 } from "@codemirror/view";
 import { useEffect, useRef } from "react";
@@ -33,6 +35,7 @@ export const Editor = ({ doc, readonly = false }: EditorProps) => {
         dropCursor(),
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         highlightActiveLine(),
+        keymap.of([indentWithTab]),
         cpp(),
         EditorState.readOnly.of(readonly),
       ],

--- a/frontend/src/components/ui/Editor.tsx
+++ b/frontend/src/components/ui/Editor.tsx
@@ -17,9 +17,18 @@ import { useEffect, useRef } from "react";
 interface EditorProps extends Omit<EditorStateConfig, "extensions"> {
   /** 編集できなくなる */
   readonly?: boolean;
+
+  onDocChange?: (s: string) => unknown;
+
+  height?: string;
 }
 
-export const Editor = ({ doc, readonly = false }: EditorProps) => {
+export const Editor = ({
+  doc,
+  height,
+  onDocChange = () => {},
+  readonly = false,
+}: EditorProps) => {
   const editor = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -38,6 +47,11 @@ export const Editor = ({ doc, readonly = false }: EditorProps) => {
         keymap.of([indentWithTab]),
         cpp(),
         EditorState.readOnly.of(readonly),
+        EditorView.updateListener.of(upd => {
+          if (upd.docChanged) {
+            onDocChange(upd.state.doc.toString());
+          }
+        }),
       ],
     });
 
@@ -51,5 +65,5 @@ export const Editor = ({ doc, readonly = false }: EditorProps) => {
     };
   }, [doc, readonly]);
 
-  return <div ref={editor} />;
+  return <div style={{ height, overflow: "auto", overscrollBehavior: "none" }} ref={editor} />;
 };


### PR DESCRIPTION
## 既知の不具合
一文字入力する度にテキストエリアのフォーカスが外れる