### PR TITLE
[frontend] コンテストページのタイマー周り修正

### DIFF
--- a/frontend/src/mocks/handlers/contest.ts
+++ b/frontend/src/mocks/handlers/contest.ts
@@ -390,7 +390,7 @@ export const contestHandlers: RequestHandler[] = [
   connectMock(ContestService, "registerMe", async (ctx, res) => {
     return res(
       ctx.delay(500),
-      ctx.status(200),
+      ctx.json({}),
     );
   }),
 ];


### PR DESCRIPTION
- [x] コンテストトップページのタイマーが0になったら「開始まで」「終了まで」などを再計算する
- [ ] サイドバーのタイマーが固定値になっているのを直す