### PR TITLE
[frontend] ログインまたはユーザ登録した後もとのページにリダイレクトで戻る

### DIFF
--- a/frontend/src/components/page/ContestSubmissionList/ContestSubmissionList.tsx
+++ b/frontend/src/components/page/ContestSubmissionList/ContestSubmissionList.tsx
@@ -21,6 +21,7 @@ import {
   Thead,
   Tr,
 } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { JudgeStatusBadge } from "../../model/judge/JudgeStatusBadge";
 import { Link } from "../../ui/Link";
@@ -137,6 +138,7 @@ type ContestSubmissionListProps = {
 };
 
 export const ContestSubmissionList = ({ mode, heading }: ContestSubmissionListProps) => {
+  const router = useRouter();
   const contestSlug = useRouterContestSlug();
   const { contest } = useGetContest({ slug: contestSlug });
   const contestId = useMemo(() => contest?.id ?? 1, [contest]);
@@ -149,7 +151,9 @@ export const ContestSubmissionList = ({ mode, heading }: ContestSubmissionListPr
         if (!user) {
           return (
             <Text>
-              自分の提出を見るには<Link href="/login">ログイン</Link>してください
+              自分の提出を見るには<Link href={"/login?redirecturi=" + encodeURIComponent(router.asPath)}>
+                ログイン
+              </Link>してください
             </Text>
           );
         }

--- a/frontend/src/components/page/ContestTop/ContestTop.tsx
+++ b/frontend/src/components/page/ContestTop/ContestTop.tsx
@@ -74,7 +74,7 @@ export const ContestTop = () => {
       );
     } else {
       toast({ title: "ログインしてから参加登録してください", status: "error" });
-      router.push("/login");
+      router.push("/login?redirecturi=" + encodeURIComponent(router.asPath));
     }
   };
 

--- a/frontend/src/components/page/Login/Login.tsx
+++ b/frontend/src/components/page/Login/Login.tsx
@@ -13,6 +13,8 @@ type FormFields = z.infer<typeof userLoginSchema>;
 
 export const Login = () => {
   const router = useRouter();
+  // router.query.redirecturi を配列にしてはいけない. 例えば redirecturi[]=/hogehoge はだめ
+  const redirecturi = (router.query.redirecturi ?? window.location.origin + "/") as string;
   const toast = useToast({
     position: "bottom",
   });
@@ -48,7 +50,7 @@ export const Login = () => {
           title: `${data.user!.username} にログインしました`,
           status: "success",
         });
-        router.push("/");
+        router.push(redirecturi);
       },
     });
   });
@@ -61,7 +63,8 @@ export const Login = () => {
         <CardHeader textAlign="center">
           <Heading as="h1" size="lg" mb={4}>ログイン</Heading>
           <p>
-            ユーザ登録をしていない方はまず <Link href="/register">こちら</Link> で登録してください
+            ユーザ登録をしていない方はまず{" "}
+            <Link href={"/register?redirecturi=" + encodeURIComponent(redirecturi)}>こちら</Link> で登録してください
           </p>
         </CardHeader>
         <CardBody>

--- a/frontend/src/components/page/Login/Login.tsx
+++ b/frontend/src/components/page/Login/Login.tsx
@@ -14,7 +14,7 @@ type FormFields = z.infer<typeof userLoginSchema>;
 export const Login = () => {
   const router = useRouter();
   // router.query.redirecturi を配列にしてはいけない. 例えば redirecturi[]=/hogehoge はだめ
-  const redirecturi = (router.query.redirecturi ?? window.location.origin + "/") as string;
+  const redirecturi = (router.query.redirecturi ?? "/") as string;
   const toast = useToast({
     position: "bottom",
   });

--- a/frontend/src/components/page/Register/Register.tsx
+++ b/frontend/src/components/page/Register/Register.tsx
@@ -26,7 +26,7 @@ type FormFields = z.infer<typeof userRegistrationSchema>;
 export const Register = () => {
   const router = useRouter();
   // router.query.redirecturi を配列にしてはいけない. 例えば redirecturi[]=/hogehoge はだめ
-  const redirecturi = (router.query.redirecturi ?? window.location.origin + "/") as string;
+  const redirecturi = (router.query.redirecturi ?? "/") as string;
   const toast = useToast({
     position: "bottom",
   });

--- a/frontend/src/components/page/Register/Register.tsx
+++ b/frontend/src/components/page/Register/Register.tsx
@@ -25,6 +25,8 @@ type FormFields = z.infer<typeof userRegistrationSchema>;
 
 export const Register = () => {
   const router = useRouter();
+  // router.query.redirecturi を配列にしてはいけない. 例えば redirecturi[]=/hogehoge はだめ
+  const redirecturi = (router.query.redirecturi ?? window.location.origin + "/") as string;
   const toast = useToast({
     position: "bottom",
   });
@@ -49,7 +51,7 @@ export const Register = () => {
           title: `${data.user!.username} で登録しました`,
           status: "success",
         });
-        router.push("/");
+        router.push(redirecturi);
       },
       onError: () => {
         toast({
@@ -70,7 +72,8 @@ export const Register = () => {
         <CardHeader textAlign="center">
           <Heading as="h1" size="lg" mb={4}>ユーザ新規登録</Heading>
           <p>
-            既に登録済みの方は <Link href="/login">ログインページ</Link> へ
+            既に登録済みの方は{" "}
+            <Link href={"/login?redirecturi=" + encodeURIComponent(redirecturi)}>ログインページ</Link> へ
           </p>
         </CardHeader>
         <CardBody textAlign="center">


### PR DESCRIPTION
## この PR でやること
ログインページ `/login` とユーザ登録ページ `/register` について，これまで{ログイン成功,登録成功}した後，必ずトップページ `/` にリダイレクトしていたのを，任意のリダイレクトパスを設定できるようにします．

fix #101 