### PR TITLE
[frontend] 順位表の proto の変更に対応

### DIFF
--- a/frontend/src/components/page/Standings/Standings.tsx
+++ b/frontend/src/components/page/Standings/Standings.tsx
@@ -35,13 +35,14 @@ type TotalScoreProps = {
   /** コンテストの得点 */
   score?: number;
   penaltyCount?: number;
-  untilAc?: number | bigint;
+  /** ペナルティを加味した回答にかかった時間. protobuf 的には Duration だが諸事情によりタイムスタンプっぽい名前になっている */
+  latestAcAt?: number | bigint; // TODO: proto とともに名前を直す
 };
 
 /**
  * 順位表のテーブルのセルに入れるための得点コンポーネント(総得点)
  */
-const TotalScore = ({ score, penaltyCount, untilAc }: TotalScoreProps) => {
+const TotalScore = ({ score, penaltyCount, latestAcAt }: TotalScoreProps) => {
   /** 1つ以上の AC を提出しているかどうか(提出があっても AC でなければだめ) */
   const hasAc = typeof score === "number" && score > 0;
   if (!hasAc) {
@@ -56,7 +57,7 @@ const TotalScore = ({ score, penaltyCount, untilAc }: TotalScoreProps) => {
           ? <Text as="span" fontWeight="bold" color="pink.400">({penaltyCount})</Text>
           : null}
       </Box>
-      {untilAc ? <Text color="gray.400">{Duration.fromNumber(untilAc).fmtHMS()}</Text> : null}
+      {latestAcAt ? <Text color="gray.400">{Duration.fromNumber(latestAcAt).fmtHMS()}</Text> : null}
     </VStack>
   );
 };
@@ -153,7 +154,9 @@ export const Standings = () => {
                           <TotalScore
                             score={record.totalScore}
                             penaltyCount={record.totalPenaltyCount}
-                            untilAc={1800000} // TODO: ペナルティを加味した untilAc 的な指標をバックエンドからもらう
+                            latestAcAt={record.latestAcAt
+                              ? record.latestAcAt.seconds * BigInt(Duration.SECOND)
+                              : undefined}
                           />
                         </Td>
                         {record.taskDetailList.map((task, j) => (

--- a/frontend/src/mocks/handlers/contest.ts
+++ b/frontend/src/mocks/handlers/contest.ts
@@ -232,11 +232,16 @@ const generateStandings = (participantsSize: number, taskSize: number) => {
       });
     }
 
+    // Protobuf Duration に seconds: bigint があるせいで Math.max が使えないので自力で最大を探す
+    const maxUntilAc = taskDetailList.map(t => t.untilAc)
+      .filter((u): u is PlainMessage<PbDuration> => u !== undefined) // 型付け目的の filter
+      .sort((a, b) => b.seconds > a.seconds ? 1 : b.seconds < a.seconds ? -1 : 0)[0];
+
     standingsNoRank.push({
       username: `user${user}`,
       totalScore: taskDetailList.reduce((accum, item) => accum + item.score, 0),
       totalPenaltyCount: taskDetailList.reduce((accum, item) => accum + item.penaltyCount, 0),
-      latestAcAt: undefined, // TODO: 削除?
+      latestAcAt: maxUntilAc, // TODO: proto とともに名前を直す 7084bd5
       taskDetailList,
     });
   }
@@ -254,7 +259,13 @@ const generateStandings = (participantsSize: number, taskSize: number) => {
 
   const [rowsGroupedByScore, groupKeys] = groupBy(standingsNoRank, s => s.totalScore); // 得点でグループ化
   const standings = Array.from(groupKeys.values()).sort((a, b) => b - a) // 得点の降順に処理する
-    .flatMap(key => rowsGroupedByScore[key]!.sort((a, b) => a.totalPenaltyCount - b.totalPenaltyCount)) // 同点はペナ少がランク高
+    .flatMap(key =>
+      rowsGroupedByScore[key]!.sort((a, b) =>
+        // @ts-expect-error undefined の可能性がある要素について比較演算子を使おうとして怒られる.
+        // Array.prototype.sort は undefined な要素を配列の末尾に並べるのでこれでも動作する.
+        a.latestAcAt.seconds > b.latestAcAt.seconds ? 1 : a.latestAcAt.seconds < b.latestAcAt.seconds ? -1 : 0
+      )
+    ) // 同点は提出が早い順
     .map<PlainMessage<StandingsRecord>>((record, i) => ({
       rank: i + 1,
       ...record,
@@ -380,14 +391,14 @@ export const contestHandlers: RequestHandler[] = [
   }),
   connectMock(ContestService, "getStandings", async (ctx, res, decodeReq, encodeResp) => {
     const { contestSlug } = await decodeReq();
-    const standingsList = standingsMap.get(contestSlug);
+    const standings = standingsMap.get(contestSlug);
 
-    if (!standingsList) {
+    if (!standings) {
       return res(ctx.status(404));
     } else {
       return res(
         ctx.delay(500),
-        encodeResp({ standingsList }),
+        encodeResp({ standingsList: standings }),
       );
     }
   }),


### PR DESCRIPTION
## この PR で解決されること
proto/backend/v1/contest_resources.proto の 7084bd5 における変更に合わせたフロントエンドのコードの修正
- Timestamp -> Duration
- ついでに得点が同点の場合にペナ少ない順ではなく提出早い順で順位を計算するように順位表のモックを改修